### PR TITLE
SS-1101 Add password help text to the signup and password reset forms

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -6,6 +6,7 @@ from typing import Optional, Sequence
 
 from django import forms
 from django.conf import settings
+from django.contrib.auth import password_validation
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
@@ -117,6 +118,7 @@ class UserForm(BootstrapErrorFormMixin, UserCreationForm):
         min_length=8,
         label="Password",
         widget=forms.PasswordInput(attrs={"class": "form-control"}),
+        help_text=password_validation.password_validators_help_text_html(),
     )
     password2 = forms.CharField(
         min_length=8,

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -40,6 +40,8 @@
                         id="new_password2">
                     </div>
 
+                    <div class="form-text">{{form.new_password1.help_text}}</div>
+
                     {% if form.new_password2.errors %}
                     <div class="pt-1">
                       {% for error in form.new_password2.errors %}

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -120,7 +120,6 @@
                                     <div class="col-12 col-md-6 pb-3 pb-md-0">
                                         <label class="form-label">{{form.password1.label_tag}}</label>
                                         {{form.password1}}
-                                        <div class="form-text">{{form.password1.help_text}}</div>
                                         {% if form.password1.errors %}
                                         <div id="validation_password1" class="pt-1 invalid-feedback">
                                             {% for error in form.password1.errors %}
@@ -142,6 +141,7 @@
                                         {% endif %}
                                     </div>
 
+                                  <div class="form-text">{{form.password1.help_text}}</div>
 
 
                                 </div>


### PR DESCRIPTION
When we were upgrading signup form, we've forgotten to add a help text for the password field. This PR fixes that. 

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

