### PR TITLE
Added `shiny_site_dir` as a field that triggers redeployment

### DIFF
--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -261,7 +261,7 @@ def create_instance_from_form(form, project, app_slug, app_id=None):
         do_deploy = True
     else:
         # Only re-deploy existing apps if one of the following fields was changed:
-        redeployment_fields = ["subdomain", "volume", "path", "flavor", "port", "image", "access"]
+        redeployment_fields = ["subdomain", "volume", "path", "flavor", "port", "image", "access", "shiny_site_dir"]
         logger.debug(f"An existing app has changed. The changed form fields: {form.changed_data}")
 
         # Because not all forms contain all fields, we check if the supposedly changed field


### PR DESCRIPTION
## Description

Small fix that enables redeployment of shiny apps in case `shiny_site_dir` is changed

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
