### PR TITLE
SS-1133 Added errors display for shiny site dir

### DIFF
--- a/templates/apps/partials/srv_prepend_append_input_group.html
+++ b/templates/apps/partials/srv_prepend_append_input_group.html
@@ -12,4 +12,12 @@
   {% if field.field.bottom_help_text %}
     <small class="form-text text-muted">{{ field.field.bottom_help_text }}</small>
   {% endif %}
+
+  {% if field.errors %}
+    {% for error in field.errors %}
+      <div class="client-validation-feedback client-validation-invalid">
+        {{ error }}
+      </div>
+    {% endfor %}
+  {% endif %}
 </div>


### PR DESCRIPTION
## Description

The fix is easy, just needed to add errors to the custom template that we use for the input group

<img width="806" alt="image" src="https://github.com/user-attachments/assets/c7ede281-5a2e-4269-b5a5-6a192ae17be5">


## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x ] I have added a reviewer for this pull request
- [x ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
