### PR TITLE
showing advance settings in custom app creation

### DIFF
--- a/apps/forms/custom.py
+++ b/apps/forms/custom.py
@@ -1,5 +1,7 @@
+from crispy_forms.bootstrap import Accordion, AccordionGroup, PrependedText
 from crispy_forms.layout import HTML, Div, Field, Layout, MultiField
 from django import forms
+from django.utils.safestring import mark_safe
 
 from apps.forms.base import AppBaseForm
 from apps.forms.field.common import SRVCommonDivField
@@ -15,10 +17,22 @@ class CustomAppForm(AppBaseForm):
     image = forms.CharField(max_length=255, required=True)
     path = forms.CharField(max_length=255, required=False)
 
+    custom_default_url = forms.CharField(max_length=255, required=False, label="Path to site_dir")
+
     def _setup_form_fields(self):
         # Handle Volume field
         super()._setup_form_fields()
         self.fields["volume"].initial = None
+
+        self.fields["custom_default_url"].widget.attrs.update({"class": "textinput form-control"})
+        self.fields["custom_default_url"].help_text = (
+            "Provide a path to the Shiny app inside your " "Docker image if it is different from /srv/shiny-server/"
+        )
+        self.fields["custom_default_url"].bottom_help_text = mark_safe(
+            "Use this field to specify subfolder if you did not place your app directly in <i>/srv/shiny-server/</i>. "
+            'You can find more about it <a href="/docs/application-hosting/shiny/#wiki-toc-advanced-settings">'
+            "in our documentation</a>."
+        )
 
     def _setup_form_helper(self):
         super()._setup_form_helper()
@@ -40,6 +54,17 @@ class CustomAppForm(AppBaseForm):
             ),
             SRVCommonDivField("port", placeholder="8000"),
             SRVCommonDivField("image"),
+            Accordion(
+                AccordionGroup(
+                    "Advanced settings",
+                    PrependedText(
+                        "custom_default_url",
+                        "/srv/shiny-server/",
+                        template="apps/partials/srv_prepend_append_input_group.html",
+                    ),
+                    active=False,
+                ),
+            ),
             css_class="card-body",
         )
         self.helper.layout = Layout(body, self.footer)
@@ -81,6 +106,7 @@ class CustomAppForm(AppBaseForm):
             "port",
             "image",
             "tags",
+            "custom_default_url",
         ]
         labels = {
             "note_on_linkonly_privacy": "Reason for choosing the link only option",

--- a/apps/models/app_types/custom/custom.py
+++ b/apps/models/app_types/custom/custom.py
@@ -1,3 +1,5 @@
+from django.db import models
+
 from apps.models import AppInstanceManager, BaseAppInstance
 
 from .base import AbstractCustomAppInstance
@@ -8,4 +10,6 @@ class CustomAppInstanceManager(AppInstanceManager):
 
 
 class CustomAppInstance(AbstractCustomAppInstance, BaseAppInstance):
+    custom_default_url = models.CharField(max_length=255, default="", blank=True)
+
     objects = CustomAppInstanceManager()


### PR DESCRIPTION
## Status

draft

## Description

when we deploy an app it show app-subdomain.serve.scilifelab.se but if user wants the base page to be app-subdomain.serve.scilifelab.se/docs then that should be configurable. There is a field in the database for each app, called url. That’s the field we need to be able to modify with the extra setting.
This should be an advanced setting field for Custom app (similar to how site_dir is an advanced field for specifically Shiny apps now).

## Types of changes

To indicate the type of change (such as bugfix or new feature), use a github pull request label.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
