### PR TITLE
Better messaging for users trying to register again

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -78,8 +78,9 @@ class SignUpView(CreateView):
                     self.request,
                     (
                         "Please check your email for a verification link."
-                        " If you don’t see it, please contact us at "
-                        "serve@scilifelab.se"
+                        " If you don’t see it, perhaps you already have an account on our service, "
+                        "try the forgot password route linked below."
+                        " Otherwise contact us at serve@scilifelab.se."
                     ),
                 )
             else:

--- a/templates/common/navbar.html
+++ b/templates/common/navbar.html
@@ -19,7 +19,7 @@
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{% url 'portal:apps' %}" target="_self" title="Apps">
-                            Apps and models
+                            Apps & Models
                         </a>
                     </li>
                     <li class="nav-item">


### PR DESCRIPTION
## Description

This PR addresses SS-1202. Users are informed that they may not receive a confirmation email after they fill out the registration form because they may already be registered, then they should use the forgot password route instead.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts