### PR TITLE
SS-1112 Enforce unique project names by owner

### DIFF
--- a/templates/projects/project_create.html
+++ b/templates/projects/project_create.html
@@ -40,6 +40,11 @@
                             {% endfor %}
                         </div>
                         {% endif %}
+                        {% if duplicate_name_error %}
+                        <div>
+                        <p class="m-0">{{ duplicate_name_error }}</p>
+                        </div>
+                        {% endif %}
                     </div>
 
                     <input type="hidden" name="template_id" value="{{template.id}}" id="template_id">


### PR DESCRIPTION
## Status

Draft

## Description

Source: https://scilifelab.atlassian.net/browse/SS-1112

The users should only be able to have a single project with a particular name. Note: this is not referring to project slug which has to be unique for Serve to work; this is only referring to better usability with unique project names.
This should not be applied to admins - we should be able to create multiple projects with the same name because this is useful when creating projects on behalf of some users (e.g. in case of courses).



## Types of changes

To indicate the type of change (such as bugfix or new feature), use a github pull request label.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
