### PR TITLE
Bugfixes before release 2.2.0

### DIFF
--- a/apps/forms/dash.py
+++ b/apps/forms/dash.py
@@ -35,7 +35,7 @@ class DashForm(AppBaseForm):
             ),
             SRVCommonDivField("source_code_url", placeholder="Provide a link to the public source code"),
             SRVCommonDivField("port", placeholder="8000"),
-            SRVCommonDivField("image", placeholder="registry/repository/image:tag"),
+            SRVCommonDivField("image", placeholder="e.g. docker.io/username/image-name:image-tag"),
             css_class="card-body",
         )
 

--- a/apps/forms/gradio.py
+++ b/apps/forms/gradio.py
@@ -39,7 +39,7 @@ class GradioForm(AppBaseForm):
                 placeholder="Describe why you want to make the app accessible only via a link",
             ),
             SRVCommonDivField("port", placeholder="7860"),
-            SRVCommonDivField("image"),
+            SRVCommonDivField("image", placeholder="e.g. docker.io/username/image-name:image-tag"),
             css_class="card-body",
         )
         self.helper.layout = Layout(body, self.footer)

--- a/apps/forms/shiny.py
+++ b/apps/forms/shiny.py
@@ -53,7 +53,7 @@ class ShinyForm(AppBaseForm):
             ),
             SRVCommonDivField("source_code_url", placeholder="Provide a link to the public source code"),
             SRVCommonDivField("port", placeholder="3838"),
-            SRVCommonDivField("image", placeholder="registry/repository/image:tag"),
+            SRVCommonDivField("image", placeholder="e.g. docker.io/username/image-name:image-tag"),
             Accordion(
                 AccordionGroup(
                     "Advanced settings",

--- a/apps/forms/streamlit.py
+++ b/apps/forms/streamlit.py
@@ -39,7 +39,7 @@ class StreamlitForm(AppBaseForm):
                 placeholder="Describe why you want to make the app accessible only via a link",
             ),
             SRVCommonDivField("port", placeholder="8501"),
-            SRVCommonDivField("image"),
+            SRVCommonDivField("image", placeholder="e.g. docker.io/username/image-name:image-tag"),
             css_class="card-body",
         )
         self.helper.layout = Layout(body, self.footer)

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -32,7 +32,9 @@ def delete_old_objects():
 
     # Handle deletion of apps in the "Develop" category
     for orm_model in APP_REGISTRY.iter_orm_models():
-        old_develop_apps = orm_model.objects.filter(created_on__lt=get_threshold(7), app__category__name="Develop")
+        old_develop_apps = orm_model.objects.filter(
+            created_on__lt=get_threshold(7), app__category__name="Develop"
+        ).exclude(app_status__status="Deleted")
 
         for app_ in old_develop_apps:
             delete_resource.delay(app_.serialize())
@@ -40,7 +42,7 @@ def delete_old_objects():
     # Handle deletion of non persistent file managers
     old_file_managers = FilemanagerInstance.objects.filter(
         created_on__lt=timezone.now() - timezone.timedelta(days=1), persistent=False
-    )
+    ).exclude(app_status__status="Deleted")
     for app_ in old_file_managers:
         delete_resource.delay(app_.serialize())
 

--- a/cypress/e2e/ui-tests/test-public-webpages.cy.js
+++ b/cypress/e2e/ui-tests/test-public-webpages.cy.js
@@ -12,7 +12,7 @@ describe("Tests of the public pages of the website", () => {
     })
 
     it("should open the Apps and models page on link click", () => {
-        cy.get("li.nav-item a").contains("Apps and models").click()
+        cy.get("li.nav-item a").contains("Apps & Models").click()
         cy.url().should("include", "/apps")
         cy.get('h3').should('contain', 'Public applications and models')
         cy.get("title").should("have.text", "Apps and models | SciLifeLab Serve (beta)")

--- a/cypress/e2e/ui-tests/test-signup.cy.js
+++ b/cypress/e2e/ui-tests/test-signup.cy.js
@@ -47,8 +47,7 @@ describe("Test sign up", () => {
         cy.url().should("include", "accounts/login");
         cy.get('.alert-success').should(
             'contain',
-            'Please check your email for a verification link.' +
-            ' If you don’t see it, please contact us at serve@scilifelab.se'
+            'Please check your email for a verification link.'
         );
 
         // TO-DO: add steps to check that email was sent, get token from email, go to email verification page, submit token there, then log in with new account

--- a/fixtures/apps_fixtures.json
+++ b/fixtures/apps_fixtures.json
@@ -383,7 +383,7 @@
   {
     "fields": {
       "category": "serve",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy:1.4.1",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/shinyproxy:1.4.2",
       "created_on": "2023-08-25T21:34:37.815Z",
       "description": "",
       "logo": "shinyapp-logo.svg",

--- a/templates/apps/logs.html
+++ b/templates/apps/logs.html
@@ -11,14 +11,14 @@
       <h3>{{ instance.name }} Logs</h3> <h5><span class="shadow badge bg-secondary" id="status-{{ instance.app.slug }}-{{ instance.pk }}"> {{ instance.status.latest.status_type }}</span></h5>
     </div>
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center">
-        <p> <span class="fw-bold"> Note:</span> Logs appear a few minutes after an app has been launched. The Status on the top right is an indication of the state of the app. {% if instance.app.slug == 'customapp' and instance.volume %} If the app is not running (due to an error) and you have a volume attached to the app, then you can switch between to the tabs below to see logs for the data copy process. The data copy tab will be shown in red in this case. If the data copy succeeds, then the data copy tab is disabled and can't be accessed. This can give you hints if data copy failed.{% endif %} </p>
+        <p> <span class="fw-bold"> Note:</span> Logs appear a few minutes after an app has been launched. The Status on the top right is an indication of the state of the app. {% if instance.app.slug in 'customapp,gradio,streamlit' and instance.volume %} If the app is not running (due to an error) and you have a volume attached to the app, then you can switch between to the tabs below to see logs for the data copy process. The data copy tab will be shown in red in this case. If the data copy succeeds, then the data copy tab is disabled and can't be accessed. This can give you hints if data copy failed.{% endif %} </p>
       </div>
     <div>
       <nav>
         <div class="nav nav-tabs" id="nav-tab" role="tablist">
           <button class="shadow nav-link nav-tab-logs active" id="nav-container1-tab" data-bs-toggle="tab" data-bs-target="#nav-container1" type="button" role="tab" aria-controls="nav-container1" aria-selected="true" onclick="updateContainer('{{ instance.subdomain.subdomain }}')">{{instance.name}}</button>
 
-          {% if instance.app.slug == 'customapp' and instance.volume %}
+          {% if instance.app.slug in 'customapp,gradio,streamlit' and instance.volume %}
           <button class="nav-link nav-tab-logs {% if instance.app_status.status == 'Running' %}disabled {% else %}nav-tab-error shadow {% endif %}" id="nav-container2-tab" data-bs-toggle="tab" data-bs-target="#nav-container2" type="button" role="tab" aria-controls="nav-container2" aria-selected="false" onclick="updateContainer('copy-to-pvc')">Data Copy</button>
           {% endif %}
         </div>


### PR DESCRIPTION
## Description

This PR contains fixes for bugs that we discovered before 2.2.0 release.
- A few e2e tests were broken because of changes in previous PRs.
- Periodic task to remove apps of type develop and file managers that are old incorrectly tried to delete already deleted apps again
- The copy data logs were not shown for gradio and streamlit app types
- Now temporarily disabled private and project permission options for gradio apps
- Update shinyproxy chart version
- Better placeholder for docker image field in app creation/edit form

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
