### PR TITLE
SS-1126 Remove access to project after deletion

### DIFF
--- a/apps/views.py
+++ b/apps/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.http import HttpResponseForbidden, JsonResponse
+from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import HttpResponseRedirect, render, reverse
 from django.utils.decorators import method_decorator
 from django.views import View
@@ -220,6 +220,9 @@ class CreateApp(View):
         # But need to make sure, that that's the only place where it's being passed
         project_slug = project
         project = Project.objects.get(slug=project_slug)
+
+        if request.user.is_superuser and project.status == "deleted":
+            return HttpResponse("This project has been deleted by the user.")
 
         form = self.get_form(request, project, app_slug, app_id)
 

--- a/projects/views.py
+++ b/projects/views.py
@@ -20,7 +20,7 @@ from django.shortcuts import render, reverse
 from django.utils.decorators import method_decorator
 from django.views import View
 from guardian.decorators import permission_required_or_403
-from guardian.shortcuts import assign_perm, remove_perm, get_users_with_perms
+from guardian.shortcuts import assign_perm, get_users_with_perms, remove_perm
 
 from apps.app_registry import APP_REGISTRY
 from apps.models import BaseAppInstance
@@ -85,6 +85,9 @@ def settings(request, project_slug):
             Q(owner=request.user) | Q(authorized=request.user),
             Q(slug=project_slug),
         ).first()
+
+    if request.user.is_superuser and project.status == "deleted":
+        return HttpResponse("This project has been deleted by the user.")
 
     try:
         User._meta.get_field("is_user")
@@ -462,6 +465,10 @@ class DetailsView(View):
 
     def get(self, request, project_slug):
         project = Project.objects.get(slug=project_slug)
+
+        if request.user.is_superuser and project.status == "deleted":
+            return HttpResponse("This project has been deleted by the user.")
+
         resources = []
         app_ids = []
         if request.user.is_superuser:
@@ -542,11 +549,11 @@ def delete(request, project_slug):
         project = Project.objects.filter(slug=project_slug).first()
 
     logger.info("SCHEDULING DELETION OF ALL INSTALLED APPS")
-    #remove permissions to see this project
+    # remove permissions to see this project
     users_with_permission = get_users_with_perms(project)
     for user in users_with_permission:
         remove_perm("can_view_project", user, project)
-    #set the status to 'deleted'
+    # set the status to 'deleted'
     project.status = "deleted"
     project.save()
     delete_project.delay(project.pk)

--- a/projects/views.py
+++ b/projects/views.py
@@ -20,7 +20,7 @@ from django.shortcuts import render, reverse
 from django.utils.decorators import method_decorator
 from django.views import View
 from guardian.decorators import permission_required_or_403
-from guardian.shortcuts import assign_perm, remove_perm
+from guardian.shortcuts import assign_perm, remove_perm, get_users_with_perms
 
 from apps.app_registry import APP_REGISTRY
 from apps.models import BaseAppInstance
@@ -542,6 +542,11 @@ def delete(request, project_slug):
         project = Project.objects.filter(slug=project_slug).first()
 
     logger.info("SCHEDULING DELETION OF ALL INSTALLED APPS")
+    #remove permissions to see this project
+    users_with_permission = get_users_with_perms(project)
+    for user in users_with_permission:
+        remove_perm("can_view_project", user, project)
+    #set the status to 'deleted'
     project.status = "deleted"
     project.save()
     delete_project.delay(project.pk)

--- a/templates/projects/partials/app_templates.html
+++ b/templates/projects/partials/app_templates.html
@@ -25,18 +25,8 @@
 
                                             {% if can_create %}
 
-                                                <!-- When models are launched REMOVE THIS -->
-                                                    {% if "Serv" in app.name or app.name == "Python Model Deployment" %}
-                                                    <a class="btn btn-primary btn-sm"
-                                                        href="">Create</a>
-                                                    {% else %}
-                                                <!-- To here -->
                                                     <a class="btn btn-primary btn-sm"
                                                         href="{% url 'apps:create' project.slug app.slug  %}?from=overview">Create</a>
-
-                                                <!-- And here -->
-                                                    {% endif %}
-                                                <!-- To here -->
 
                                             {% else %}
                                             <button class="btn btn-secondary btn-sm" style="cursor: default;"


### PR DESCRIPTION
## Description

This PR relates to issue SS-1126. Previously, after project deletion if the user would try to open the deleted project page (e.g. it was bookmarked) they would get stuck in an infinite refresh loop. In case of superusers, they are informed that they are trying to access a project that has been removed.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts