### PR TITLE
restrict N of apps on the homepage to only 6

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -152,9 +152,9 @@ class HomeView(View):
     def get(self, request, app_id=0):
         published_apps_updated_on, request = get_public_apps(
             request, app_id=app_id, order_by="updated_on", order_reverse=True
-        )[
-            :6
-        ]  # we display only 6 apps
+        )
+        published_apps_updated_on = published_apps_updated_on[:6]  # we display only 6 apps
+        # TODO: add selection of N apps into the function so that it is optimized in the future with more apps in the db
 
         news_objects = NewsObject.objects.all().order_by("-created_on")
         link_all_news = False


### PR DESCRIPTION
## Description

Hotfix to display only the first 6 apps on the homepage.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
