### PR TITLE
SS 1348 Hotfix to fix function to cleanup old file manager and notebook apps

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -26,11 +26,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from apps.helpers import (
-    HandleUpdateStatusResponseCode,
-    get_select_options,
-    handle_update_status_request,
-)
+from apps.constants import HandleUpdateStatusResponseCode
+from apps.helpers import get_select_options, handle_update_status_request
 from apps.models import AppCategories, Apps, BaseAppInstance, Subdomain
 from apps.tasks import delete_resource
 from apps.types_.subdomain import SubdomainCandidateName

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -2,9 +2,11 @@ import time
 
 from django.contrib import admin, messages
 from django.db.models.query import QuerySet
+from django.utils import timezone
 
 from studio.utils import get_logger
 
+from .constants import ActionSourceCode
 from .helpers import get_URI
 from .models import (
     AppCategories,
@@ -151,7 +153,12 @@ class BaseAppAdmin(admin.ModelAdmin):
 
         for instance in queryset:
             instance.set_k8s_values()
-            delete_resource.delay(instance.serialize())
+            # Set latest_user_action to Deleting
+            # This hides the app from the user UI
+            instance.latest_user_action = "Deleting"
+            instance.deleted_on = timezone.now()
+            instance.save(update_fields=["latest_user_action", "deleted_on"])
+            delete_resource.delay(instance.serialize(), ActionSourceCode.USER.value)
             info_dict = instance.info
             if info_dict:
                 success = info_dict["helm"].get("success", False)

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from studio.utils import get_logger
 
-from .constants import ActionSourceCode
+from .constants import AppActionOrigin
 from .helpers import get_URI
 from .models import (
     AppCategories,
@@ -158,7 +158,7 @@ class BaseAppAdmin(admin.ModelAdmin):
             instance.latest_user_action = "Deleting"
             instance.deleted_on = timezone.now()
             instance.save(update_fields=["latest_user_action", "deleted_on"])
-            delete_resource.delay(instance.serialize(), ActionSourceCode.USER.value)
+            delete_resource.delay(instance.serialize(), AppActionOrigin.USER.value)
             info_dict = instance.info
             if info_dict:
                 success = info_dict["helm"].get("success", False)

--- a/apps/constants.py
+++ b/apps/constants.py
@@ -1,16 +1,17 @@
-from enum import Enum
+from enum import IntEnum
 
 
-class HandleUpdateStatusResponseCode(Enum):
+class HandleUpdateStatusResponseCode(IntEnum):
     NO_ACTION = 0
     UPDATED_STATUS = 1
     UPDATED_TIME_OF_STATUS = 2
     CREATED_FIRST_STATUS = 3
 
 
-class ActionSourceCode(Enum):
-    USER = 0
-    SYSTEM = 1
+class AppActionOrigin(IntEnum):
+    UNSET = 0
+    USER = 1
+    SYSTEM = 2
 
 
 HELP_MESSAGE_MAP = {

--- a/apps/constants.py
+++ b/apps/constants.py
@@ -1,3 +1,18 @@
+from enum import Enum
+
+
+class HandleUpdateStatusResponseCode(Enum):
+    NO_ACTION = 0
+    UPDATED_STATUS = 1
+    UPDATED_TIME_OF_STATUS = 2
+    CREATED_FIRST_STATUS = 3
+
+
+class ActionSourceCode(Enum):
+    USER = 0
+    SYSTEM = 1
+
+
 HELP_MESSAGE_MAP = {
     "name": "Display name for the application. This is the name visible on the app catalogue if the app is public",
     "description": "Provide a detailed description of your app. "

--- a/apps/constants.py
+++ b/apps/constants.py
@@ -1,4 +1,4 @@
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 
 
 class HandleUpdateStatusResponseCode(IntEnum):
@@ -8,10 +8,10 @@ class HandleUpdateStatusResponseCode(IntEnum):
     CREATED_FIRST_STATUS = 3
 
 
-class AppActionOrigin(IntEnum):
-    UNSET = 0
-    USER = 1
-    SYSTEM = 2
+class AppActionOrigin(StrEnum):
+    UNSET = "UNSET"
+    USER = "USER"
+    SYSTEM = "SYSTEM"
 
 
 HELP_MESSAGE_MAP = {

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 
-from apps.constants import ActionSourceCode, HandleUpdateStatusResponseCode
+from apps.constants import AppActionOrigin, HandleUpdateStatusResponseCode
 from apps.types_.subdomain import SubdomainCandidateName
 from studio.utils import get_logger
 
@@ -387,7 +387,7 @@ def handle_subdomain_change(instance: Any, subdomain: str, subdomain_name: str) 
     if instance.subdomain.subdomain != subdomain_name:
         # The user modified the subdomain name
         # In this special case, we avoid async task.
-        delete_resource(instance.serialize(), ActionSourceCode.USER.value)
+        delete_resource(instance.serialize(), AppActionOrigin.USER.value)
         old_subdomain = instance.subdomain
         instance.subdomain = subdomain
         instance.save(update_fields=["subdomain"])

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from enum import Enum
 from typing import Any, Optional
 
 import regex as re
@@ -7,6 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 
+from apps.constants import ActionSourceCode, HandleUpdateStatusResponseCode
 from apps.types_.subdomain import SubdomainCandidateName
 from studio.utils import get_logger
 
@@ -96,13 +96,6 @@ def handle_permissions(parameters, project):
     return access
 
 
-class HandleUpdateStatusResponseCode(Enum):
-    NO_ACTION = 0
-    UPDATED_STATUS = 1
-    UPDATED_TIME_OF_STATUS = 2
-    CREATED_FIRST_STATUS = 3
-
-
 def handle_update_status_request(
     release: str, new_status: str, event_ts: datetime, event_msg: Optional[str] = None
 ) -> HandleUpdateStatusResponseCode:
@@ -134,6 +127,7 @@ def handle_update_status_request(
             instance = BaseAppInstance.objects.select_for_update().filter(subdomain=subdomain).last()
             if instance is None:
                 logger.info(f"The specified app instance identified by release {release} was not found")
+                # TODO: This should not raise an exception. It is not a problematic event.
                 raise ObjectDoesNotExist
 
             logger.debug(f"The app instance identified by release {release} exists. App name={instance.name}")
@@ -393,7 +387,7 @@ def handle_subdomain_change(instance: Any, subdomain: str, subdomain_name: str) 
     if instance.subdomain.subdomain != subdomain_name:
         # The user modified the subdomain name
         # In this special case, we avoid async task.
-        delete_resource(instance.serialize())
+        delete_resource(instance.serialize(), ActionSourceCode.USER.value)
         old_subdomain = instance.subdomain
         instance.subdomain = subdomain
         instance.save(update_fields=["subdomain"])

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -10,6 +10,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from apps.app_registry import APP_REGISTRY
+from apps.constants import ActionSourceCode
 from studio.celery import app
 from studio.utils import get_logger
 
@@ -23,6 +24,9 @@ CHART_REGEX = re.compile(r"^(?P<chart>.+):(?P<version>.+)$")
 @app.task
 def delete_old_objects():
     """
+    Execution of this function is considered a System-initiated action, hence action=SystemDeleting
+    and initiated_by=SYSTEM.
+
     This function retrieves the old apps based on the given threshold, category, and model class.
     It then iterates through the subclasses of BaseAppInstance and deletes the old apps
     for both the "Develop" and "Manage Files" categories.
@@ -41,7 +45,7 @@ def delete_old_objects():
         # old: .exclude(app_status__status="Deleted")
 
         for app_ in old_develop_apps:
-            delete_resource.delay(app_.serialize())
+            delete_resource.delay(app_.serialize(), ActionSourceCode.SYSTEM.value)
 
     # Handle deletion of non persistent file managers
     old_file_managers = FilemanagerInstance.objects.filter(
@@ -50,7 +54,7 @@ def delete_old_objects():
     # old: .exclude(app_status__status="Deleted")
 
     for app_ in old_file_managers:
-        delete_resource.delay(app_.serialize())
+        delete_resource.delay(app_.serialize(), ActionSourceCode.SYSTEM.value)
 
 
 @app.task
@@ -281,7 +285,24 @@ def deploy_resource(serialized_instance):
 
 @shared_task
 @transaction.atomic
-def delete_resource(serialized_instance):
+def delete_resource(serialized_instance, initiated_by_str: str):
+    """
+    Deletes a cluster resource object.
+    For deletes that are initiated by the system itself (such as recurring tasks),
+    the field latest_user_action is set to SystemDeleting. Deletes initiated by end users
+    are instead handled by views.
+    Note that initiated by is needed because this information cannot be determined
+    from the latest_user_action as this is sometimes set after the deletion of the resource.
+
+    Parameters:
+    - serialized_instance: A serialized version of the app to be deleted.
+    - initiated_by_str: A string of enum ActionSourceCode indicating the source of the deletion (user|system).
+    """
+    logger.debug(f"Type of serialized_instance is {type(serialized_instance)}")
+
+    initiated_by = ActionSourceCode(initiated_by_str)
+    assert initiated_by == ActionSourceCode.USER or initiated_by == ActionSourceCode.SYSTEM
+
     instance = deserialize(serialized_instance)
 
     values = instance.k8s_values
@@ -303,8 +324,8 @@ def delete_resource(serialized_instance):
         # There is no need to save a FailedToDelete status
         # We let the k8s event listener handle this event and together with
         # the instance info we have sufficient troubleshooting information.
-        # This can occur if for example the deployment has already been deleted.
-        logger.warn(f"FAILED to delete resource type {instance.app.slug}, {values['subdomain']}, error={error}")
+        # Note: This can occur if for example the deployment has already been deleted.
+        logger.info(f"Failed to delete resource type {instance.app.slug}, {values['subdomain']}, error={error}")
 
     helm_info = {"success": success, "info": {"stdout": output, "stderr": error}}
 
@@ -312,11 +333,13 @@ def delete_resource(serialized_instance):
 
     # Note: when we save the app instance object here, we should not overwrite properties
     # with old values, therefore we carefully restrict the updated fields.
-    if instance.app.slug in ("volumeK8s", "netpolicy"):
-        # These "apps" are not true user apps but rather handled
-        # by the Serve system. Therefore they are set to the SystemDeleting action.
+    # if instance.app.slug in ("volumeK8s", "netpolicy"):
+    if initiated_by == ActionSourceCode.SYSTEM:
+        # The delete resource action was initiated by the Serve system.
+        # This is a common scenario for "apps" such as volumeK8s, netpolicy, notebooks and file managers.
         instance.latest_user_action = "SystemDeleting"
-        instance.save(update_fields=["latest_user_action", "info"])
+        instance.deleted_on = timezone.now()
+        instance.save(update_fields=["latest_user_action", "deleted_on", "info"])
     else:
         instance.save(update_fields=["info"])
 

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -39,9 +39,11 @@ def delete_old_objects():
 
     # Handle deletion of apps in the "Develop" category
     for orm_model in APP_REGISTRY.iter_orm_models():
-        old_develop_apps = orm_model.objects.filter(
-            created_on__lt=get_threshold(7), app__category__name="Develop"
-        ).exclude(latest_user_action="SystemDeleting")
+        old_develop_apps = (
+            orm_model.objects.filter(created_on__lt=get_threshold(7), app__category__name="Develop")
+            .exclude(latest_user_action="SystemDeleting")
+            .exclude(app__slug="mlflow")
+        )
         # old: .exclude(app_status__status="Deleted")
 
         for app_ in old_develop_apps:

--- a/apps/tests/test_app_helper_utils.py
+++ b/apps/tests/test_app_helper_utils.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from projects.models import Flavor, Project
 
 from ..app_registry import APP_REGISTRY
-from ..constants import ActionSourceCode
+from ..constants import AppActionOrigin
 from ..forms import DashForm
 from ..helpers import create_instance_from_form, get_subdomain_name
 from ..models import Apps, DashInstance, K8sUserAppStatus, Subdomain
@@ -234,7 +234,7 @@ class UpdateExistingAppInstanceTestCase(TestCase):
         # Modifying the subdomain should cause a re-deploy:
         mock_deploy.assert_called_once()
         # Modifying the subdomain SHOULD cause a delete:
-        mock_delete.assert_called_once_with(ANY, ActionSourceCode.USER.value)
+        mock_delete.assert_called_once_with(ANY, AppActionOrigin.USER.value)
 
     def test_update_instance_from_form_modify_no_redeploy_values(self, mock_delete, mock_deploy):
         """

--- a/apps/tests/test_app_helper_utils.py
+++ b/apps/tests/test_app_helper_utils.py
@@ -1,6 +1,6 @@
 """This module is used to test the helper functions that are used by user app instance functionality."""
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -9,6 +9,7 @@ from django.test import TestCase
 from projects.models import Flavor, Project
 
 from ..app_registry import APP_REGISTRY
+from ..constants import ActionSourceCode
 from ..forms import DashForm
 from ..helpers import create_instance_from_form, get_subdomain_name
 from ..models import Apps, DashInstance, K8sUserAppStatus, Subdomain
@@ -86,7 +87,7 @@ class CreateAppInstanceTestCase(TestCase):
 
 # Mock the tasks that manipulate k8s resources.
 # Note that these are passed to the test functions in reverse order.
-# The delete_resource task is used sync (wuthout delay) in helpers.
+# The delete_resource task is used sync (without delay) in helpers.
 @patch("apps.tasks.deploy_resource.delay")
 @patch("apps.tasks.delete_resource")
 class UpdateExistingAppInstanceTestCase(TestCase):
@@ -233,7 +234,7 @@ class UpdateExistingAppInstanceTestCase(TestCase):
         # Modifying the subdomain should cause a re-deploy:
         mock_deploy.assert_called_once()
         # Modifying the subdomain SHOULD cause a delete:
-        mock_delete.assert_called_once()
+        mock_delete.assert_called_once_with(ANY, ActionSourceCode.USER.value)
 
     def test_update_instance_from_form_modify_no_redeploy_values(self, mock_delete, mock_deploy):
         """

--- a/apps/tests/test_update_status_handler.py
+++ b/apps/tests/test_update_status_handler.py
@@ -10,7 +10,8 @@ from django.test import TestCase, TransactionTestCase
 
 from projects.models import Project
 
-from ..helpers import HandleUpdateStatusResponseCode, handle_update_status_request
+from ..constants import HandleUpdateStatusResponseCode
+from ..helpers import handle_update_status_request
 from ..models import AppCategories, Apps, JupyterInstance, K8sUserAppStatus, Subdomain
 
 utc = pytz.UTC

--- a/apps/views.py
+++ b/apps/views.py
@@ -19,6 +19,7 @@ from projects.models import Project
 from studio.utils import get_logger
 
 from .app_registry import APP_REGISTRY
+from .constants import ActionSourceCode
 from .helpers import create_instance_from_form
 from .models import BaseAppInstance
 from .tasks import delete_resource
@@ -192,7 +193,7 @@ def delete(request, project, app_slug, app_id):
 
     serialized_instance = instance.serialize()
 
-    delete_resource.delay(serialized_instance)
+    delete_resource.delay(serialized_instance, ActionSourceCode.USER.value)
 
     # fix: in case appinstance is public switch to private
     instance.access = "private"

--- a/apps/views.py
+++ b/apps/views.py
@@ -19,7 +19,7 @@ from projects.models import Project
 from studio.utils import get_logger
 
 from .app_registry import APP_REGISTRY
-from .constants import ActionSourceCode
+from .constants import AppActionOrigin
 from .helpers import create_instance_from_form
 from .models import BaseAppInstance
 from .tasks import delete_resource
@@ -193,7 +193,7 @@ def delete(request, project, app_slug, app_id):
 
     serialized_instance = instance.serialize()
 
-    delete_resource.delay(serialized_instance, ActionSourceCode.USER.value)
+    delete_resource.delay(serialized_instance, AppActionOrigin.USER.value)
 
     # fix: in case appinstance is public switch to private
     instance.access = "private"

--- a/projects/tasks.py
+++ b/projects/tasks.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from apps.app_registry import APP_REGISTRY
-from apps.constants import ActionSourceCode
+from apps.constants import AppActionOrigin
 from apps.helpers import create_instance_from_form
 from apps.models import BaseAppInstance, VolumeInstance
 from apps.tasks import delete_resource
@@ -186,7 +186,7 @@ def delete_project_apps(project):
             instance.latest_user_action = "Deleting"
             instance.deleted_on = timezone.now()
             instance.save(update_fields=["latest_user_action", "deleted_on"])
-            delete_resource(serialized_instance, ActionSourceCode.USER.value)
+            delete_resource(serialized_instance, AppActionOrigin.USER.value)
 
 
 @shared_task

--- a/projects/tasks.py
+++ b/projects/tasks.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from apps.app_registry import APP_REGISTRY
+from apps.constants import ActionSourceCode
 from apps.helpers import create_instance_from_form
 from apps.models import BaseAppInstance, VolumeInstance
 from apps.tasks import delete_resource
@@ -180,9 +181,12 @@ def delete_project_apps(project):
         queryset = orm_model.objects.filter(project=project)
         for instance in queryset:
             serialized_instance = instance.serialize()
+            # Set latest_user_action to Deleting
+            # This hides the app from the user UI
             instance.latest_user_action = "Deleting"
-            instance.save(update_fields=["latest_user_action"])
-            delete_resource(serialized_instance)
+            instance.deleted_on = timezone.now()
+            instance.save(update_fields=["latest_user_action", "deleted_on"])
+            delete_resource(serialized_instance, ActionSourceCode.USER.value)
 
 
 @shared_task

--- a/templates/projects/categories/develop.html
+++ b/templates/projects/categories/develop.html
@@ -6,8 +6,4 @@
 
 {% block bottom_content %}
 
-<div class="mx-4 mb-4 small text-muted">
-*Note that all apps under Develop will be deleted 7 days after creation.
-</div>
-
 {% endblock%}


### PR DESCRIPTION
## Description

This PR is a hotfix against the production (main) branch. It fixes a bug in version 3.0.0 with the function that should delete old file manager and Jupyter Lab notebook apps. It sets the latest user action code to SystemDeleting for any apps that are deleted by the system itself (vs end user) thereby correctly handling these in the UI and k8s deletion task. It does so by introducing a required argument initiated_by (AppActionOrigin) to the delete_resource task to indicate the initiating source of the action.

For more information and recommended tests to verify, see:
Jira [link](https://scilifelab.atlassian.net/browse/SS-1348)

## Checklist

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
