### PR TITLE
SS 1374 Upgrade the event listener k8s API

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -942,6 +942,12 @@ def update_app_status(request: HttpRequest) -> HttpResponse:
                     200,
                 )
 
+            elif result == HandleUpdateStatusResponseCode.OBJECT_NOT_FOUND:
+                return Response(
+                    f"OK. OBJECT_NOT_FOUND. The specified app instance was not found {release=}",
+                    404,
+                )
+
             else:
                 logger.error(f"Unknown return code from handle_update_status_request() = {result}", exc_info=True)
                 return Response(f"Unknown return code from handle_update_status_request() = {result}", 500)

--- a/apps/constants.py
+++ b/apps/constants.py
@@ -6,6 +6,7 @@ class HandleUpdateStatusResponseCode(IntEnum):
     UPDATED_STATUS = 1
     UPDATED_TIME_OF_STATUS = 2
     CREATED_FIRST_STATUS = 3
+    OBJECT_NOT_FOUND = 4
 
 
 class AppActionOrigin(StrEnum):

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -109,7 +109,6 @@ def handle_update_status_request(
     :param event_ts timestamp: A JSON-formatted timestamp in UTC, e.g. 2024-01-25T16:02:50.00Z.
     :param event_msg json dict: An optional json dict containing pod-msg and/or container-msg.
     :returns: A value from the HandleUpdateStatusResponseCode enum.
-              Raises an ObjectDoesNotExist exception if the app instance does not exist.
     """
 
     if len(new_status) > 20:
@@ -127,8 +126,7 @@ def handle_update_status_request(
             instance = BaseAppInstance.objects.select_for_update().filter(subdomain=subdomain).last()
             if instance is None:
                 logger.info(f"The specified app instance identified by release {release} was not found")
-                # TODO: This should not raise an exception. It is not a problematic event.
-                raise ObjectDoesNotExist
+                return HandleUpdateStatusResponseCode.OBJECT_NOT_FOUND
 
             logger.debug(f"The app instance identified by release {release} exists. App name={instance.name}")
 
@@ -173,6 +171,10 @@ def handle_update_status_request(
             status_object = instance.k8s_user_app_status
             update_k8s_user_app_status(instance, status_object, new_status, event_ts, event_msg)
             return HandleUpdateStatusResponseCode.UPDATED_STATUS
+
+    except ObjectDoesNotExist:
+        logger.info(f"No such subdomain exists identified by release={release}")
+        return HandleUpdateStatusResponseCode.OBJECT_NOT_FOUND
 
     except Exception as err:
         logger.error(f"Unable to fetch or update the specified app instance with release={release}. {err}, {type(err)}")

--- a/apps/tests/test_update_status_handler.py
+++ b/apps/tests/test_update_status_handler.py
@@ -24,11 +24,12 @@ test_user = {"username": "foo@test.com", "email": "foo@test.com", "password": "b
 class UpdateAppStatusNonExistingAppTestCase(TestCase):
     """Test case for request of non-existing app instance."""
 
-    def test_handle_nonexisting_app_should_raise_exception(self):
+    def test_handle_nonexisting_app(self):
         release = "non-existing-app-release"
 
-        with self.assertRaises(ObjectDoesNotExist):
-            handle_update_status_request(release, "NewStatus", datetime.now)
+        actual = handle_update_status_request(release, "NewStatus", datetime.now)
+
+        assert actual == HandleUpdateStatusResponseCode.OBJECT_NOT_FOUND
 
 
 class UpdateAppStatusTestCase(TestCase):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
   event-listener:
     user: "${UID}:${GID}"
     container_name: event-listener
-    image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v1.0.0
+    image: ghcr.io/scilifelabdatacentre/serve-event-listener/event-listener:v1.1.0
     env_file:
       - .env
     volumes:

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -8,7 +8,7 @@ if $INIT; then
 
     if [ -n "${RESET_DB}" ] && [ "${RESET_DB}" = "true" ] && [ -n "${DEBUG}" ] && [ "${DEBUG}" = "true" ]; then
         echo "RESETTING DATABASE..."
-        python manage.py reset_db --no-input
+        python manage.py reset_db --no-input --close-sessions
         echo "Uninstalling all Helm releases in serve-dev namespace"
         helm uninstall $(helm ls --all --short -n serve-dev) -n serve-dev
     fi


### PR DESCRIPTION
## Description

This PR uses the latest event-listener service which upgrades the Kubernetes Python API to version 32. There are some other minor changes, such as a delay introduced in the event-listener when handling Deleted events. Also requests to update non-existent app instances is treated as less severe as this can happen for non-catastrophic reasons.

It also adds a close-sessions flag to the reset_db handling for local and development environments when re-creating the database.

Jira [link](https://scilifelab.atlassian.net/browse/SS-1374)

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
