### PR TITLE
Bug: Password URL error in E2E tests

### DIFF
--- a/cypress/e2e/ui-tests/test-login-account-handling.cy.js
+++ b/cypress/e2e/ui-tests/test-login-account-handling.cy.js
@@ -98,7 +98,7 @@ describe("Test login, profile page view, password change, password reset", () =>
         cy.visit("/")
         cy.get('button.btn-profile').click()
         cy.get('li.btn-group').find('a').contains("Change password").click()
-        cy.url().should("include", "accounts/password_change/")
+        cy.url().should("include", "password-change/")
 
         cy.get('input[name=old_password]').type(users.login_user.password)
         cy.get('input[name=new_password1]').type(users.login_user.reset_password)


### PR DESCRIPTION
## Description

An E2E test is failing on the develop branch (see image attached).

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [X] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts


<img width="1228" alt="e2e_error" src="https://github.com/user-attachments/assets/43843800-34be-4844-89e2-e319e1f7611f" />
