### PR TITLE
Bug: Explicit error on bad container image

### DIFF
--- a/cypress/e2e/integration-tests/test-deploy-app.cy.js
+++ b/cypress/e2e/integration-tests/test-deploy-app.cy.js
@@ -757,11 +757,10 @@ describe("Test deploying app", () => {
             cy.get('tr:contains("' + app_name + '")').find('a').contains('Settings').click()
             cy.get('#id_image').type("-BAD")
             cy.get('#submit-id-submit').contains('Submit').click()
-            // Back on project page
-            cy.url().should("not.include", "/apps/settings")
-            cy.get('h3').should('have.text', project_name);
-            // Verify that the app status now equals Image Error
-            verifyAppStatus(app_name, "Image Error", "public")
+            // Stay on the Settings page
+            cy.url().should("include", "/apps/settings")
+            // Verify that the input field has the error class
+            cy.get('#id_image').should('have.class', 'is-invalid');
 
             // Edit Dash app: modify the app image back to a valid image
             cy.logf("Editing the dash app settings field Image to a valid value", Cypress.currentTest)

--- a/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
+++ b/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
@@ -854,6 +854,9 @@ if (Cypress.env('create_resources') === true) {
             // Stay on the Settings page
             cy.url().should("include", "/apps/settings")
 
+            // Verify that the input field has the error class
+            cy.get('#id_image').should('have.class', 'is-invalid');
+
             // The final app status and latest user action:
             // Wait for 5 seconds and check the app status again
             // This relies on the k8s event listener

--- a/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
+++ b/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
@@ -851,11 +851,8 @@ if (Cypress.env('create_resources') === true) {
             cy.get('tr:contains("' + app_name + '")').find('a').contains('Settings').click()
             cy.get('#id_image').type("-BAD")
             cy.get('#submit-id-submit').should('be.visible').contains('Submit').click()
-            // Back on project page
-            cy.url().should("not.include", "/apps/settings")
-            cy.get('h3').should('have.text', project_name);
-
-            verifyAppStatus(app_name, "", "public", "Changing")
+            // Stay on the Settings page
+            cy.url().should("include", "/apps/settings")
 
             // The final app status and latest user action:
             // Wait for 5 seconds and check the app status again

--- a/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
+++ b/cypress/e2e/ui-tests/test-user-manage-apps.cy.js
@@ -857,16 +857,6 @@ if (Cypress.env('create_resources') === true) {
             // Verify that the input field has the error class
             cy.get('#id_image').should('have.class', 'is-invalid');
 
-            // The final app status and latest user action:
-            // Wait for 5 seconds and check the app status again
-            // This relies on the k8s event listener
-            // Verify that the app status now equals Error
-            if (env_run_extended_k8s_checks === true) {
-                cy.wait(5000).then(() => {
-                    verifyAppStatus(app_name, "Error", "public", "Changing")
-                })
-            }
-
             // Edit Dash app: modify the app image back to a valid image
             cy.logf("Editing the dash app settings field Image to a valid value", Cypress.currentTest)
             cy.visit("/projects/")


### PR DESCRIPTION
## Description

When creating or updating an app with an invalid container image, the form is submitted without validation. We need to modify the tests so that the app update does not go through, inline with the more recent expected behaviour.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [X] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
