### PR TITLE
SS-1398 mlflow subdomain bug fix

### DIFF
--- a/apps/types_/subdomain.py
+++ b/apps/types_/subdomain.py
@@ -50,9 +50,10 @@ class SubdomainCandidateName:
 
         # Check if the subdomain adheres to helm rules
         regex_validator = RegexValidator(
-            regex=r"^(?!-)[a-z0-9-]{3,53}(?<!-)$",
+            regex=r"^(?!-)(?!.*mlflow)[a-z0-9-]{3,53}(?<!-)$",
             message="Subdomain must be 3-53 characters long, contain only lowercase letters, digits, hyphens, "
-            "and cannot start or end with a hyphen",
+            "cannot contain 'mlflow', "
+            "and cannot start or end with a hyphen.",
         )
 
         regex_validator(self.__name)

--- a/apps/types_/subdomain.py
+++ b/apps/types_/subdomain.py
@@ -50,10 +50,9 @@ class SubdomainCandidateName:
 
         # Check if the subdomain adheres to helm rules
         regex_validator = RegexValidator(
-            regex=r"^(?!-)(?!.*mlflow)[a-z0-9-]{3,53}(?<!-)$",
+            regex=r"^(?!-)[a-z0-9-]{3,53}(?<!-)$",
             message="Subdomain must be 3-53 characters long, contain only lowercase letters, digits, hyphens, "
-            "cannot contain 'mlflow', "
-            "and cannot start or end with a hyphen.",
+            "and cannot start or end with a hyphen",
         )
 
         regex_validator(self.__name)

--- a/apps/views.py
+++ b/apps/views.py
@@ -320,10 +320,16 @@ class SecretsView(View):
         username, password = None, None
         if instance.get_app_status() == "Running":
             subdomain = instance.subdomain
+            # If release name contains chart name it will be used as a full name.
+            # see here: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_names.tpl#L21-L37
+            if "mlflow" in subdomain.subdomain.lower():
+                secret_name = f"{subdomain.subdomain}-tracking"
+            else:
+                secret_name = f"{subdomain.subdomain}-mlflow-tracking"
             username = subprocess.run(
                 (
                     "kubectl get secret "
-                    f"--namespace {settings.NAMESPACE} {subdomain.subdomain}-mlflow-tracking "
+                    f"--namespace {settings.NAMESPACE} {secret_name} "
                     '-o jsonpath="{.data.admin-user}"'
                 ).split(),
                 check=True,
@@ -334,7 +340,7 @@ class SecretsView(View):
             password = subprocess.run(
                 (
                     "kubectl get secret "
-                    f"--namespace {settings.NAMESPACE} {subdomain.subdomain}-mlflow-tracking "
+                    f"--namespace {settings.NAMESPACE} {secret_name} "
                     '-o jsonpath="{.data.admin-password}"'
                 ).split(),
                 check=True,

--- a/templates/apps/secrets_view.html
+++ b/templates/apps/secrets_view.html
@@ -24,21 +24,23 @@
           <h1 class="h3 mb-3 card-title">Your MLflow Credentials</h1>
           <p class="card-text">Use the credentials below to access MLflow.</p>
 
-          <div class="mb-3">
-            <label for="mlflow-username" class="form-label">Username</label>
-            <div class="input-group">
-              <input type="text" id="mlflow-username" class="form-control" value="{{ mlflow_username }}" readonly>
-              <button class="btn btn-outline-secondary" onclick="copyToClipboard('mlflow-username')">Copy</button>
+            <!-- Updated Username Section -->
+            <div class="mb-3">
+              <label class="form-label">Username</label>
+              <div class="d-flex align-items-center gap-2">
+                <code class="p-2 bg-light rounded flex-grow-1" id="mlflow-username">{{ mlflow_username }}</code>
+                <button class="btn btn-outline-secondary" onclick="copyToClipboard('mlflow-username')">Copy</button>
+              </div>
             </div>
-          </div>
 
-          <div class="mb-3">
-            <label for="mlflow-password" class="form-label">Password</label>
-            <div class="input-group">
-              <input type="text" id="mlflow-password" class="form-control" value="{{ mlflow_password }}" readonly>
-              <button class="btn btn-outline-secondary" onclick="copyToClipboard('mlflow-password')">Copy</button>
+            <!-- Updated Password Section -->
+            <div class="mb-3">
+              <label class="form-label">Password</label>
+              <div class="d-flex align-items-center gap-2">
+                <code class="p-2 bg-light rounded flex-grow-1" id="mlflow-password">{{ mlflow_password }}</code>
+                <button class="btn btn-outline-secondary" onclick="copyToClipboard('mlflow-password')">Copy</button>
+              </div>
             </div>
-          </div>
 
           <div class="text-center mt-4">
             <a href="{{ mlflow_url }}" target="_blank" class="btn btn-dark">Open MLflow</a>
@@ -70,12 +72,47 @@ mlflow.set_registry_uri("{{ mlflow_url }}")</code></pre>
   </div>
 
   <script>
-      function copyToClipboard(elementId) {
-          var copyText = document.getElementById(elementId);
-          copyText.select();
-          copyText.setSelectionRange(0, 99999); // For mobile devices
-          navigator.clipboard.writeText(copyText.value);
+
+  async function copyToClipboard(elementId) {
+    const el = document.getElementById(elementId);
+    const text = el.textContent;
+    const tempTextArea = document.createElement('textarea');
+
+    try {
+      // Modern clipboard API (requires HTTPS)
+      await navigator.clipboard.writeText(text);
+
+      // Visual feedback
+      const btn = document.querySelector(`button[onclick*='${elementId}']`);
+      btn.classList.add('btn-success');
+      setTimeout(() => btn.classList.remove('btn-success'), 1000);
+
+    } catch (err) {
+      // Fallback for older browsers/HTTP
+      try {
+        tempTextArea.value = text;
+        document.body.appendChild(tempTextArea);
+        tempTextArea.select();
+        document.execCommand('copy');
+
+        // Fallback visual feedback
+        const btn = document.querySelector(`button[onclick*='${elementId}']`);
+        btn.classList.add('btn-info');
+        setTimeout(() => btn.classList.remove('btn-info'), 1000);
+
+      } catch (fallbackErr) {
+        // Ultimate fallback: show text and prompt manual copy
+        tempTextArea.style.position = 'fixed';
+        tempTextArea.style.top = '10px';
+        tempTextArea.style.left = '10px';
+        tempTextArea.style.zIndex = 1000;
+        alert('Press Ctrl/Cmd+C to copy:\n\n' + text);
       }
+    } finally {
+      document.body.removeChild(tempTextArea);
+    }
+  }
+
   </script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Status

Ready for review

## Description

1. MLFlow: When user opens secrets page and agrees to auto fill credentials, mlflow credentials overridden

Source: https://scilifelab.atlassian.net/browse/SS-1398

2. MLFlow: When user sets subdomain with `mlflow` in it, secrets are not generated according to the `secrets page` pattern

Source: https://scilifelab.atlassian.net/browse/SS-1397

The root cause of the mlflow subdomain bug is that, the chart avoids redundant naming when the release name already contains mlflow, but appends -mlflow otherwise. This conditional logic is why only mlflow-containing subdomains fail. The logic is implemented [here: ](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_names.tpl#L21-L37). From there,

`If release name contains chart name it will be used as a full name.`

## Types of changes

bugfix

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
