### PR TITLE
SS -1442 Add API for Serve content stats

### DIFF
--- a/api/openapi/content_stats_api.py
+++ b/api/openapi/content_stats_api.py
@@ -1,10 +1,11 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
+from django.contrib.auth.models import User
 from django.http import JsonResponse
-from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
-from rest_framework.exceptions import NotFound
 
+from apps.models import BaseAppInstance
+from projects.models import Project
 from studio.utils import get_logger
 
 logger = get_logger(__name__)
@@ -20,39 +21,135 @@ class ContentStatsAPI(viewsets.ReadOnlyModelViewSet):
     - TODO
     """
 
+    # A dict of pre-defined app types in the system.
+    # Undefined app types are dynamically added during processing.
+    # TODO: consider using APP_REGISTRY
+    apps_by_type: dict[str, int] = {
+        "customapp": 0,
+        "dashapp": 0,
+        "gradioapp": 0,
+        "shinyapp": 0,
+        "streamlitapp": 0,
+        "tissuumapsapp": 0,
+    }
+
     def get_stats(self, request):
+        logger.info("Open API resource content-stats called")
+
         stats = {}
 
+        success = True
+        success_msg = None
+
+        # Set to default values
         n_default: int = -1
 
-        apps_by_type: dict = {
-            "custom": n_default,
-            "dash": n_default,
-            "gradio": n_default,
-            "shiny": n_default,
-            "streamlit": n_default,
-            "tissuumaps": n_default,
-        }
+        n_projects = n_default
+        n_users = n_default
+        n_apps = n_default
 
         new_users_by_year: list = []
 
         users_by_univ: list = []
 
         apps_by_image_registry: dict = {
-            "dockerhub": n_default,
-            "ghcr": n_default,
+            "dockerhub": 0,
+            "ghcr": 0,
         }
 
+        # Projects
+        try:
+            n_projects = Project.objects.filter(status="active").distinct("pk").count()
+        except Exception as e:
+            success = False
+            success_msg = _append_status_msg(success_msg, "Error setting number of projects (n_projects).")
+            logger.warning(f"Unable to get the number of active projects: {e}", exc_info=True)
+
+        # Users
+        try:
+            n_users = User.objects.filter(is_active=True).count()
+        except Exception as e:
+            success = False
+            success_msg = _append_status_msg(success_msg, "Error setting number of users (n_users).")
+            logger.warning(f"Unable to get the number of active users: {e}", exc_info=True)
+
+        # Apps
+        # Since we loop over apps to retrieve image registry info,
+        # we also collect all app attributes in the same way.
+        try:
+            apps = BaseAppInstance.objects.get_app_instances_not_deleted()
+            n_apps = 0
+
+            for app in apps:
+                if app.app.category.slug == "serve":
+                    n_apps += 1
+
+                    # Collect app image registry information
+                    if app.chart is None:
+                        raise Exception("This app has no chart")
+                    elif "ghcr.io" in app.chart:
+                        apps_by_image_registry["ghcr"] += 1
+                    else:
+                        apps_by_image_registry["dockerhub"] += 1
+
+                    # Collect app type information
+                    if "shiny" in app.app.slug:
+                        # Combine all shiny types into one app type
+                        self._append_app_type("shinyapp")
+                    else:
+                        self._append_app_type(app.app.slug)
+
+        except Exception as e:
+            success = False
+            msg = f"Error setting apps information (n_apps or apps_by_image_registry). {e}"
+            success_msg = _append_status_msg(success_msg, msg)
+            logger.warning(f"Unable to get the number of user apps: {e}", exc_info=True)
+
+        # Add the generic top-level elements
         stats["stats_date_utz"] = datetime.now(timezone.utc)
-        stats["n_projects"] = n_default
-        stats["n_users"] = n_default
-        stats["n_apps"] = n_default
-        stats["apps_by_type"] = apps_by_type
+        stats["stats_success"] = success
+        stats["stats_message"] = success_msg
+
+        # Add content-specific elements
+        stats["n_projects"] = n_projects
+        stats["n_users"] = n_users
+        stats["n_apps"] = n_apps
+        stats["apps_by_type"] = ContentStatsAPI.apps_by_type
         stats["new_users_by_year"] = new_users_by_year
         stats["users_by_university"] = users_by_univ
         stats["apps_by_image_registry"] = apps_by_image_registry
 
+        # Apps
+        """
+        app = apps[0]
+        stats["app1_name"] = app.name
+        stats["app1_chart"] = app.app.chart
+        stats["app1_app_name"] = app.app.name
+        stats["app1_app_category.slug"] = app.app.category.slug
+        stats["app1_app_slug"] = app.app.slug
+
+        model_class = apps.model
+        fields = model_class._meta.get_fields()
+        column_names = [field.name for field in fields]
+        stats["apps_fields"] = column_names
+        """
+
         data = {"data": stats}
-        logger.info("STATS: %s", data)
 
         return JsonResponse(data)
+
+    def _append_app_type(self, app_type: str) -> None:
+        """Constructs and increments app type counts."""
+        if app_type in ContentStatsAPI.apps_by_type:
+            ContentStatsAPI.apps_by_type[app_type] += 1
+        else:
+            # Append the app type as a new key
+            ContentStatsAPI.apps_by_type[app_type] = 1
+
+
+def _append_status_msg(status_msg: str, new_msg: str) -> str:
+    """Simple helper function to format status messages."""
+    if status_msg is None:
+        return new_msg
+    else:
+        return f"{status_msg} {new_msg}"

--- a/api/openapi/content_stats_api.py
+++ b/api/openapi/content_stats_api.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta, timezone
+
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from rest_framework import viewsets
+from rest_framework.exceptions import NotFound
+
+from studio.utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class ContentStatsAPI(viewsets.ReadOnlyModelViewSet):
+    """
+    The Content Stats API with read-only methods to get aggregated statistics
+    about the content in the system.
+
+    The top-level elements nested under data include:
+    - stats-date
+    - TODO
+    """
+
+    def get_stats(self, request):
+        stats = {}
+
+        n_default: int = -1
+
+        apps_by_type: dict = {
+            "custom": n_default,
+            "dash": n_default,
+            "gradio": n_default,
+            "shiny": n_default,
+            "streamlit": n_default,
+            "tissuumaps": n_default,
+        }
+
+        new_users_by_year: list = []
+
+        users_by_univ: list = []
+
+        apps_by_image_registry: dict = {
+            "dockerhub": n_default,
+            "ghcr": n_default,
+        }
+
+        stats["stats_date_utz"] = datetime.now(timezone.utc)
+        stats["n_projects"] = n_default
+        stats["n_users"] = n_default
+        stats["n_apps"] = n_default
+        stats["apps_by_type"] = apps_by_type
+        stats["new_users_by_year"] = new_users_by_year
+        stats["users_by_university"] = users_by_univ
+        stats["apps_by_image_registry"] = apps_by_image_registry
+
+        data = {"data": stats}
+        logger.info("STATS: %s", data)
+
+        return JsonResponse(data)

--- a/api/openapi/content_stats_api.py
+++ b/api/openapi/content_stats_api.py
@@ -120,12 +120,21 @@ class ContentStatsAPI(viewsets.ReadOnlyModelViewSet):
                     n_apps += 1
 
                     # Collect app image registry information
-                    if app.chart is None:
-                        raise Exception("This app has no chart")
-                    elif "ghcr.io" in app.chart:
-                        apps_by_image_registry["ghcr"] += 1
+                    image = None
+                    if app.k8s_values is not None and "appconfig" in app.k8s_values:
+                        app_config = app.k8s_values["appconfig"]
+                        if "image" in app_config and app_config["image"] is not None:
+                            image = app_config["image"]
+
+                    if image is None:
+                        logger.info(
+                            "An app is missing image information so it was skipped from the image registry counts."
+                        )
                     else:
-                        apps_by_image_registry["dockerhub"] += 1
+                        if "ghcr.io" in image:
+                            apps_by_image_registry["ghcr"] += 1
+                        else:
+                            apps_by_image_registry["dockerhub"] += 1
 
                     # Collect app type information
                     if "shiny" in app.app.slug:

--- a/api/openapi/urls.py
+++ b/api/openapi/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 from rest_framework_nested import routers
 
 from .common_api import APIInfo, are_you_there, get_system_version
+from .content_stats_api import ContentStatsAPI
 from .lookups_api import DepartmentLookupAPI, UniversityLookupAPI
 from .public_apps_api import PublicAppsAPI
 
@@ -19,9 +20,11 @@ urlpatterns = [
     path("are-you-there", are_you_there),
     path("system-version", get_system_version),
     path("api-info", APIInfo.as_view({"get": "get_api_info"})),
-    # The Apps API
+    # The Public apps resource API
     path("public-apps", PublicAppsAPI.as_view({"get": "list_apps"})),
     path("public-apps/<str:app_slug>/<int:pk>", PublicAppsAPI.as_view({"get": "retrieve"})),
+    # The Content statistics resource API
+    path("content-stats", ContentStatsAPI.as_view({"get": "get_stats"})),
     # Supplementary lookups API
     path(
         "lookups/universities",

--- a/api/tests/test_openapi_content_stats.py
+++ b/api/tests/test_openapi_content_stats.py
@@ -1,0 +1,129 @@
+import json
+import os
+from datetime import datetime
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.models import AppCategories, Apps, K8sUserAppStatus, ShinyInstance, Subdomain
+from common.models import UserProfile
+from projects.models import Project
+from studio.utils import get_logger
+
+logger = get_logger(__name__)
+
+
+User = get_user_model()
+
+test_user = {"username": "foo@test.com", "email": "foo@test.com", "password": "bar"}
+
+
+class ContentStatsApiTests(APITestCase):
+    """Tests for the content stats API resource endpoints"""
+
+    BASE_API_URL = "/openapi/v1/"
+
+    def load_data(self):
+        # Create a public app with status Running
+        self.user = User.objects.create_user(test_user["username"], test_user["email"], test_user["password"])
+        self.profile = UserProfile.objects.create(user=self.user, is_approved=True, affiliation="slu")
+        self.project = Project.objects.create_project(name="test-perm", owner=self.user, description="")
+        self.category = AppCategories.objects.create(name="Serve", priority=100, slug="serve")
+
+        # App type shinyproxyapp should be combined with shiny app so good to test shiny
+        self.app = Apps.objects.create(name="Shiny Proxy App", slug="shinyproxyapp", category=self.category)
+
+        subdomain = Subdomain.objects.create(subdomain="test_internal")
+        k8s_user_app_status = K8sUserAppStatus.objects.create(status="Running")
+        self.app_instance = ShinyInstance.objects.create(
+            access="public",
+            owner=self.user,
+            name="test_open_api_content_stats_app",
+            description="My app description",
+            app=self.app,
+            project=self.project,
+            k8s_values={
+                "appconfig": {"port": 9999, "image": "ghcr.io/scilifelabdatacentre/test-shiny:3"},
+            },
+            subdomain=subdomain,
+            k8s_user_app_status=k8s_user_app_status,
+        )
+
+    def test_with_preloaded_contents(self):
+        """Tests the API resource with some pre-loaded users, projects and apps."""
+
+        self.load_data()
+
+        url = os.path.join(self.BASE_API_URL, "content-stats")
+        response = self.client.get(url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        actual = json.loads(response.content)["data"]
+
+        self.assertIsNotNone(actual)
+        self.assertIsInstance(actual, dict)
+        self.assertTrue(len(actual) > 1)
+
+        self.assertIsNotNone(actual["stats_date_utz"])
+        stats_date = datetime.strptime(actual["stats_date_utz"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        self.assertIsInstance(stats_date, datetime)
+        self.assertEqual(stats_date.date(), datetime.today().date())
+
+        self.assertTrue(actual["stats_success"])
+        self.assertIsNone(actual["stats_message"])
+
+        self.assertEqual(actual["n_projects"], 1)
+        self.assertEqual(actual["n_users"], 1)
+        self.assertEqual(actual["n_apps"], 1)
+
+        self.assertIsNotNone(actual["apps_by_type"])
+        self.assertTrue(len(actual["apps_by_type"]) > 1)
+        self.assertEqual(actual["apps_by_type"]["shinyapp"], 1)
+
+        self.assertEqual(actual["new_users_by_year"], {str(datetime.today().year): 1})
+
+        self.assertEqual(actual["users_by_university"], {"slu": 1})
+
+        self.assertIsNotNone(actual["apps_by_image_registry"])
+        self.assertEqual(len(actual["apps_by_image_registry"]), 2)
+        self.assertEqual(actual["apps_by_image_registry"]["dockerhub"], 0)
+        self.assertEqual(actual["apps_by_image_registry"]["ghcr"], 1)
+
+    def test_with_empty_contents(self):
+        """Tests the API resource against an empty system."""
+
+        url = os.path.join(self.BASE_API_URL, "content-stats")
+        response = self.client.get(url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        actual = json.loads(response.content)["data"]
+
+        self.assertIsNotNone(actual)
+        self.assertIsInstance(actual, dict)
+        self.assertTrue(len(actual) > 1)
+
+        self.assertIsNotNone(actual["stats_date_utz"])
+        stats_date = datetime.strptime(actual["stats_date_utz"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        self.assertIsInstance(stats_date, datetime)
+        self.assertEqual(stats_date.date(), datetime.today().date())
+        self.assertTrue(actual["stats_success"])
+        self.assertIsNone(actual["stats_message"])
+
+        self.assertEqual(actual["n_projects"], 0)
+        self.assertEqual(actual["n_users"], 0)
+        self.assertEqual(actual["n_apps"], 0)
+
+        self.assertIsNotNone(actual["apps_by_type"])
+        self.assertTrue(len(actual["apps_by_type"]) > 1)
+
+        self.assertEqual(actual["new_users_by_year"], {})
+
+        self.assertEqual(actual["users_by_university"], {})
+
+        self.assertIsNotNone(actual["apps_by_image_registry"])
+        self.assertEqual(len(actual["apps_by_image_registry"]), 2)
+        self.assertEqual(actual["apps_by_image_registry"]["dockerhub"], 0)
+        self.assertEqual(actual["apps_by_image_registry"]["ghcr"], 0)


### PR DESCRIPTION
## Description

This PR adds an Open API endpoint with current and past content aggregated statistics such as the number of projects and apps.

The API resource is named content-stats and can be reached at endpoint /openapi/v1/content-stats

Jira [link](https://scilifelab.atlassian.net/browse/SS-1442)

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
