### PR TITLE
SS-1149 Configure AXES to use client IP

### DIFF
--- a/studio/settings.py
+++ b/studio/settings.py
@@ -245,6 +245,9 @@ AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT = False
 AXES_DISABLE_ACCESS_LOG = True
 # The custom view template to display on locked out event
 AXES_LOCKOUT_TEMPLATE = "registration/locked_out.html"
+# Configure AXES to use the real user client IP considering reverse proxy deployments
+AXES_IPWARE_PROXY_COUNT = None  # Number of reverse proxies in front of Django (None or 1)
+AXES_IPWARE_META_PRECEDENCE_ORDER = ["HTTP_X_FORWARDED_FOR", "HTTP_X_REAL_IP", "REMOTE_ADDR"]
 
 # Django guardian 403 templates
 GUARDIAN_RENDER_403 = True


### PR DESCRIPTION
## Description

This PR configures AXES brute force protection to work with client IP:s considering reverse proxy servers and load balancer environments by adding 2 new settings to the Django settings:

AXES_IPWARE_PROXY_COUNT
AXES_IPWARE_META_PRECEDENCE_ORDER

Jira [link](https://scilifelab.atlassian.net/browse/SS-1149)

## Checklist

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [x] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
