### PR TITLE
ss-1523 Integrate app IP count into Serve UI

### DIFF
--- a/api/services/loki.py
+++ b/api/services/loki.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Set
 
 import requests
+from django.conf import settings
 
 from studio.utils import get_logger
-from django.conf import settings
 
 logger = get_logger(__name__)
 

--- a/api/services/loki.py
+++ b/api/services/loki.py
@@ -3,12 +3,9 @@ from typing import Any, Dict, Set
 import requests
 
 from studio.utils import get_logger
+from django.conf import settings
 
 logger = get_logger(__name__)
-
-# TODO unfortunately for now we have to hardcode the loki reader endpoint
-# This code is expected to be removed in the future as this is a temporary solution we have in place
-LOKI_READER_ENDPOINT = "http://loki-read-headless.loki-stack.svc.cluster.local:3100"
 
 
 def process_loki_response(response_json: Dict[str, Any]) -> Set[str]:
@@ -44,7 +41,7 @@ def query_unique_ip_count(app_subdomain: str = "") -> int:
         logger.error("app_subdomain must be provided")
         raise ValueError("app_subdomain must be provided")
 
-    endpoint = f"{LOKI_READER_ENDPOINT}/loki/api/v1/query_range"
+    endpoint = f"{settings.LOKI_READER_ENDPOINT}/loki/api/v1/query_range"
 
     query = (
         r'{container="rke2-ingress-nginx-controller"} |= "'

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -7,6 +7,7 @@ import requests
 import waffle
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.forms.models import model_to_dict
@@ -23,7 +24,6 @@ from apps.validators.container_images import (
 from common.models import UserProfile
 from projects.models import Project
 from studio.utils import get_logger
-from django.core.cache import cache
 
 from .models import Apps, BaseAppInstance, K8sUserAppStatus, Subdomain
 

--- a/apps/helpers.py
+++ b/apps/helpers.py
@@ -23,6 +23,7 @@ from apps.validators.container_images import (
 from common.models import UserProfile
 from projects.models import Project
 from studio.utils import get_logger
+from django.core.cache import cache
 
 from .models import Apps, BaseAppInstance, K8sUserAppStatus, Subdomain
 
@@ -832,3 +833,8 @@ def get_minio_usage(minio_service_name: str) -> Optional[Tuple[float, float]]:
 
     # Convert to GiB and round
     return (round(used_bytes / GIB_FACTOR, 2), round(total_bytes / GIB_FACTOR, 2))
+
+
+def get_cached_ip_count(subdomain):
+    """Get IP count from cache, return 0 if not found"""
+    return cache.get(f"ip_{subdomain}", 0)

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -16,6 +16,8 @@ from studio.utils import get_logger
 
 from .models import BaseAppInstance, FilemanagerInstance
 
+from django.core.cache import cache
+from api.services.loki import query_unique_ip_count
 logger = get_logger(__name__)
 
 CHART_REGEX = re.compile(r"^(?P<chart>.+):(?P<version>.+)$")
@@ -366,3 +368,22 @@ def deserialize(serialized_instance):
         raise ValueError(f"Invalid serialized data format: {e}")
     except ObjectDoesNotExist:
         raise ValueError(f"No instance found for model {model} with pk {pk}")
+
+
+@app.task
+def update_cached_app_ip_counts():
+    """Update cached IP counts of every app subdomain."""
+    
+    logger.info("Starting IP count update task")
+
+    apps = BaseAppInstance.objects.filter(subdomain__isnull=False).select_related('subdomain')
+
+    for app in apps:
+        try:
+            subdomain = app.subdomain.subdomain
+            count = query_unique_ip_count(app_subdomain=subdomain)
+            cache.set(f"ip_{subdomain}", count, None)  # Cache indefinitely
+        except Exception as e:
+            logger.warning(f"Failed to update {subdomain}: {e}")
+
+    logger.info(f"Updated cached IP counts for {apps.count()} apps.")

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -378,9 +378,9 @@ def update_cached_app_ip_counts():
 
     apps = BaseAppInstance.objects.filter(subdomain__isnull=False).select_related("subdomain")
 
-    for app in apps:
+    for serve_app in apps:
         try:
-            subdomain = app.subdomain.subdomain
+            subdomain = serve_app.subdomain.subdomain
             count = query_unique_ip_count(app_subdomain=subdomain)
             cache.set(f"ip_{subdomain}", count, None)  # Cache indefinitely
         except Exception as e:

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -5,10 +5,12 @@ import yaml
 from celery import shared_task
 from django.apps import apps
 from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.utils import timezone
 
+from api.services.loki import query_unique_ip_count
 from apps.app_registry import APP_REGISTRY
 from apps.constants import AppActionOrigin
 from studio.celery import app
@@ -16,8 +18,6 @@ from studio.utils import get_logger
 
 from .models import BaseAppInstance, FilemanagerInstance
 
-from django.core.cache import cache
-from api.services.loki import query_unique_ip_count
 logger = get_logger(__name__)
 
 CHART_REGEX = re.compile(r"^(?P<chart>.+):(?P<version>.+)$")
@@ -373,10 +373,10 @@ def deserialize(serialized_instance):
 @app.task
 def update_cached_app_ip_counts():
     """Update cached IP counts of every app subdomain."""
-    
+
     logger.info("Starting IP count update task")
 
-    apps = BaseAppInstance.objects.filter(subdomain__isnull=False).select_related('subdomain')
+    apps = BaseAppInstance.objects.filter(subdomain__isnull=False).select_related("subdomain")
 
     for app in apps:
         try:

--- a/fixtures/intervals_fixtures.json
+++ b/fixtures/intervals_fixtures.json
@@ -88,5 +88,13 @@
     },
     "model": "django_celery_beat.crontabschedule",
     "pk": 6
-  }
+  },
+  {
+    "fields": {
+      "every": 1,
+      "period": "days"
+    },
+    "model": "django_celery_beat.intervalschedule",
+    "pk": 7
+}
 ]

--- a/fixtures/periodic_tasks_fixtures.json
+++ b/fixtures/periodic_tasks_fixtures.json
@@ -166,5 +166,33 @@
     },
     "model": "django_celery_beat.periodictask",
     "pk": 10
+  },
+  {
+    "fields": {
+      "args": "[]",
+      "clocked": null,
+      "crontab": null,
+      "date_changed": "2025-01-01T00:00:00.000Z",
+      "description": "Updates unique IP counts for app instances from Loki logs",
+      "enabled": true,
+      "exchange": null,
+      "expire_seconds": null,
+      "expires": null,
+      "headers": "{}",
+      "interval": 7,
+      "kwargs": "{}",
+      "last_run_at": null,
+      "name": "update_cached_app_ip_counts",
+      "one_off": false,
+      "priority": null,
+      "queue": null,
+      "routing_key": null,
+      "solar": null,
+      "start_time": null,
+      "task": "apps.tasks.update_cached_app_ip_counts",
+      "total_run_count": 0
+    },
+    "model": "django_celery_beat.periodictask",
+    "pk": 11
   }
 ]

--- a/projects/views.py
+++ b/projects/views.py
@@ -601,12 +601,10 @@ class DetailsView(View):
 
             # Add IP count to each instance
             for instance in instances_per_category_list:
-                instance.unique_ip_count = 0
+                instance.unique_visitors_ip_count = 0
                 if hasattr(instance, "subdomain") and instance.subdomain:
                     if (request.user == instance.owner) or request.user.is_superuser:
-                        instance.ip_count = get_cached_ip_count(instance.subdomain.subdomain)
-                else:
-                    instance.ip_count = 0
+                        instance.unique_visitors_ip_count = get_cached_ip_count(instance.subdomain.subdomain)
 
             # Filter the available apps specified in the project template
             available_apps = [app.pk for app in project.project_template.available_apps.all()]

--- a/projects/views.py
+++ b/projects/views.py
@@ -22,7 +22,7 @@ from guardian.shortcuts import assign_perm, get_users_with_perms, remove_perm
 
 from apps.app_registry import APP_REGISTRY
 from common.tasks import send_email_task
-
+from apps.helpers import get_cached_ip_count
 from .exceptions import ProjectCreationException
 from .models import Environment, Flavor, Project, ProjectLog, ProjectTemplate
 from .tasks import create_resources_from_template, delete_project
@@ -597,6 +597,15 @@ class DetailsView(View):
                     instances_per_category_list.extend(
                         [instance for instance in queryset_per_category if instance not in instances_per_category_list]
                     )
+
+            # Add IP count to each instance
+            for instance in instances_per_category_list:
+                instance.unique_ip_count = 0
+                if hasattr(instance, 'subdomain') and instance.subdomain:
+                    if (request.user == instance.owner) or request.user.is_superuser:
+                        instance.ip_count = get_cached_ip_count(instance.subdomain.subdomain)
+                else:
+                    instance.ip_count = 0
 
             # Filter the available apps specified in the project template
             available_apps = [app.pk for app in project.project_template.available_apps.all()]

--- a/projects/views.py
+++ b/projects/views.py
@@ -21,8 +21,9 @@ from guardian.decorators import permission_required_or_403
 from guardian.shortcuts import assign_perm, get_users_with_perms, remove_perm
 
 from apps.app_registry import APP_REGISTRY
-from common.tasks import send_email_task
 from apps.helpers import get_cached_ip_count
+from common.tasks import send_email_task
+
 from .exceptions import ProjectCreationException
 from .models import Environment, Flavor, Project, ProjectLog, ProjectTemplate
 from .tasks import create_resources_from_template, delete_project
@@ -601,7 +602,7 @@ class DetailsView(View):
             # Add IP count to each instance
             for instance in instances_per_category_list:
                 instance.unique_ip_count = 0
-                if hasattr(instance, 'subdomain') and instance.subdomain:
+                if hasattr(instance, "subdomain") and instance.subdomain:
                     if (request.user == instance.owner) or request.user.is_superuser:
                         instance.ip_count = get_cached_ip_count(instance.subdomain.subdomain)
                 else:

--- a/studio/settings.py
+++ b/studio/settings.py
@@ -571,6 +571,17 @@ if not DEBUG:
 
 LOKI_SVC = None
 
+LOKI_READER_ENDPOINT = "http://loki-read-headless.loki-stack.svc.cluster.local:3100"
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': f'redis://{REDIS_HOST}:{REDIS_PORT}/1', # https://redis.io/docs/latest/commands/select/
+        'KEY_PREFIX': 'serve',
+        'TIMEOUT': 7200,  # 2 hours default but will be overriden
+    }
+}
+
 # k8s cluster version for validation of manifests
 CLUSTER_VERSION = "1.32"
 

--- a/studio/settings.py
+++ b/studio/settings.py
@@ -574,11 +574,11 @@ LOKI_SVC = None
 LOKI_READER_ENDPOINT = "http://loki-read-headless.loki-stack.svc.cluster.local:3100"
 
 CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
-        'LOCATION': f'redis://{REDIS_HOST}:{REDIS_PORT}/1', # https://redis.io/docs/latest/commands/select/
-        'KEY_PREFIX': 'serve',
-        'TIMEOUT': 7200,  # 2 hours default but will be overriden
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/1",  # https://redis.io/docs/latest/commands/select/
+        "KEY_PREFIX": "serve",
+        "TIMEOUT": 7200,  # 2 hours default but will be overriden
     }
 }
 

--- a/templates/projects/partials/app_instances_table.html
+++ b/templates/projects/partials/app_instances_table.html
@@ -9,6 +9,7 @@
             <th class="d-none d-xxl-table-cell " tabindex="0" rowspan="1" colspan="1">Created</th>
             <th class="" tabindex="0" rowspan="1" colspan="1">Status</th>
             <th class="" tabindex="0" rowspan="1" colspan="1">Permissions</th>
+            <th class="" tabindex="0" rowspan="1" colspan="1">Hits <span class="bi bi-question-circle text-muted" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-original-title="Unique IP visits during the last 30 days"></span></th>
             <th class="d-none d-xxl-table-cell " tabindex="0" rowspan="1" colspan="1">Tags</th>
             <th tabindex="0" rowspan="1" colspan="1">Actions</th>
         </tr>
@@ -69,6 +70,9 @@
                     {% endif %}
                 {% endif %}
               {% endif %}
+            </td>
+            <td data-cy="hits-cell">
+                {{ instance.ip_count }}
             </td>
             <td class="d-none d-xxl-table-cell" id="tags-{{ instance.pk }}">
                 {% for tag in instance.tags.all %}

--- a/templates/projects/partials/app_instances_table.html
+++ b/templates/projects/partials/app_instances_table.html
@@ -72,8 +72,8 @@
               {% endif %}
             </td>
             <td data-cy="hits-cell">
-            {% if instance.ip_count != 0 %}
-                {{ instance.ip_count }}
+            {% if instance.unique_visitors_ip_count != 0 %}
+                {{ instance.unique_visitors_ip_count }}
             {% endif %}
             </td>
             <td class="d-none d-xxl-table-cell" id="tags-{{ instance.pk }}">

--- a/templates/projects/partials/app_instances_table.html
+++ b/templates/projects/partials/app_instances_table.html
@@ -72,7 +72,9 @@
               {% endif %}
             </td>
             <td data-cy="hits-cell">
+            {% if instance.ip_count != 0 %}
                 {{ instance.ip_count }}
+            {% endif %}
             </td>
             <td class="d-none d-xxl-table-cell" id="tags-{{ instance.pk }}">
                 {% for tag in instance.tags.all %}


### PR DESCRIPTION
## Description

https://scilifelab.atlassian.net/browse/SS-1523

Create a Celery task that runs a Loki query to collect unique IP visits to every app on Serve in the last 30 days. The value is saved in Redis using Django cache and then displayed on the user project view.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [x] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
