### PR TITLE
SS-1548 Mark container api dependant tests as integration

### DIFF
--- a/apps/tests/test_validate_docker_image_architecture.py
+++ b/apps/tests/test_validate_docker_image_architecture.py
@@ -10,6 +10,7 @@ from apps.validators.container_images import (
 )
 
 
+@pytest.mark.integration
 def test_ghcr_architecture_is_valid():
     architectures = get_image_architectures(
         auth=GHCRAuthenticator(),
@@ -21,6 +22,7 @@ def test_ghcr_architecture_is_valid():
     assert architectures == [ImageArchitectureTuple(os="linux", arch="amd64")]
 
 
+@pytest.mark.integration
 def test_get_anonymous_bearer_token():
     auth = GHCRAuthenticator()
     token = auth.get_token_service_url("scilifelabdatacentre/serve-jupyterlab")
@@ -29,6 +31,7 @@ def test_get_anonymous_bearer_token():
     assert "token" in resp.json(), "Token not found in response"
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(
     condition="settings.DOCKER_HUB_TOKEN is None",
 )

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -166,7 +166,7 @@ services:
     image: stackn:base
     volumes:
     - .:/app:cached
-    command: ["pytest", "-n", "auto"]
+    command: ["pytest", "-n", "auto", "-m", "not integration"]
     profiles:
       - donotstart
     networks:

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,6 @@ python_files = tests.py test_*.py *_tests.py
 
 # Coverage configurations
 addopts = --cov=. --no-cov-on-fail --cov-report=term-missing
+
+markers =
+    integration: marks test as an integration test, which means, that it relies on external resource


### PR DESCRIPTION
## Description

This pr introduces `pytest.mark.integration` to mark unittests that rely on some external resources to run.

They will be skipped in CI 

## Types of changes

To indicate the type of change (such as bugfix or new feature), use a github pull request label.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts

## Further comments

Anything else you think we should know before merging your code!
