### PR TITLE
SS-1575 fix broken form manager link

### DIFF
--- a/templates/portal/teaching.html
+++ b/templates/portal/teaching.html
@@ -27,7 +27,7 @@
         <h4 id="application">Application form</h4>
 
         <div class="container">
-            <form class="needs-validation" action="https://forms.dckube.scilifelab.se/api/v1/form/noRF3FO03F_2F8pL/incoming" method="POST" accept-charset="utf-8">
+            <form class="needs-validation" action="https://forms.dc.scilifelab.se/api/v1/form/lBN7bZBOomI5XwG6/incoming" method="POST" accept-charset="utf-8">
             <input type='hidden' name='csrfmiddlewaretoken' value='{{ csrf_token }}' />
             <div class="row justify-content-center">
               <div class="col-6 border rounded p-4">


### PR DESCRIPTION
This change relates to [SS-1575](https://scilifelab.atlassian.net/browse/SS-1575). The form manager has been moved to a new url and that has been changed. Also, the older form is not visible on my account so I have added a new form in the form manager and will give access to it for the team.

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have included, reviewed and executed tests (unit and end2end) to complement my changes
- [ ] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
