### PR TITLE
SS-2001 Depictio SnippetsFilter for custom error pages

### DIFF
--- a/apps/models/app_types/depictio.py
+++ b/apps/models/app_types/depictio.py
@@ -52,32 +52,43 @@ class DepictioInstance(BaseAppInstance, SocialMixin):
                     }
                 ],
             }
+            # SnippetsFilter allows only one snippet per context, so blocks are
+            # merged per context below rather than appended as separate entries.
+            snippets_by_context = {
+                "http.server": [
+                    "location @custom_error_page {\n"
+                    "    internal;\n"
+                    "    proxy_set_header X-Code $status;\n"
+                    f"    proxy_pass http://nginx-errors.{settings.NAMESPACE}.svc.cluster.local;\n"
+                    "}"
+                ],
+                "http.server.location": [
+                    "proxy_intercept_errors on;\nerror_page 502 503 = @custom_error_page;",
+                ],
+            }
             if self.access in ("private", "project"):
-                gateway_values["snippetsFilter"] = {
-                    "enabled": True,
-                    "snippets": [
-                        {
-                            "context": "http.server",
-                            "value": (
-                                f"location @login_redirect {{\n"
-                                f"    return 302 https://{settings.DOMAIN}/accounts/login/?next=$request_uri;\n"
-                                f"}}\n"
-                                f"location = /_depictio_auth {{\n"
-                                f"    internal;\n"
-                                f"    client_max_body_size {self.upload_size}M;\n"
-                                f"    proxy_pass {settings.AUTH_PROTOCOL}://{settings.AUTH_DOMAIN}:8080/auth/?release={release_name};\n"
-                                f"    proxy_pass_request_body off;\n"
-                                f'    proxy_set_header Content-Length "";\n'
-                                f"    proxy_set_header X-Original-URI $request_uri;\n"
-                                f"}}"
-                            ),
-                        },
-                        {
-                            "context": "http.server.location",
-                            "value": "auth_request /_depictio_auth;\nerror_page 401 = @login_redirect;",
-                        },
-                    ],
-                }
+                snippets_by_context["http.server"].append(
+                    f"location @login_redirect {{\n"
+                    f"    return 302 https://{settings.DOMAIN}/accounts/login/?next=$request_uri;\n"
+                    f"}}\n"
+                    f"location = /_depictio_auth {{\n"
+                    f"    internal;\n"
+                    f"    client_max_body_size {self.upload_size}M;\n"
+                    f"    proxy_pass {settings.AUTH_PROTOCOL}://{settings.AUTH_DOMAIN}:8080/auth/?release={release_name};\n"
+                    f"    proxy_pass_request_body off;\n"
+                    f'    proxy_set_header Content-Length "";\n'
+                    f"    proxy_set_header X-Original-URI $request_uri;\n"
+                    f"}}"
+                )
+                snippets_by_context["http.server.location"].append(
+                    "auth_request /_depictio_auth;\nerror_page 401 = @login_redirect;"
+                )
+            gateway_values["snippetsFilter"] = {
+                "enabled": True,
+                "snippets": [
+                    {"context": context, "value": "\n".join(values)} for context, values in snippets_by_context.items()
+                ],
+            }
             k8s_values["gateway"] = gateway_values
         else:
             if self.access in ("private", "project"):


### PR DESCRIPTION
## Description

Jira: https://scilifelab.atlassian.net/browse/SS-2001

Make the changes needed for Depictio to start serving custom error pages similar to the other apps.
This is done from the override logic instead of Depictio's own Helm chart.

## TODO

- [x] works locally with Helm
- [x] works on Serve dev

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [X] This pull request is against **develop** branch (not applicable for hotfixes)
- [X] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [ ] I have ran unit and end2end tests
- [ ] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [ ] I have updated the related documentation (if necessary)
- [X] I have added a reviewer for this pull request
- [X] I have added myself as an author for this pull request
- [ ] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

# PR cheatsheet

- PR -- pull request
- Include jira ticket in the PR title (like `SS-1234 Introduced machine learning ai driven framework for DDLS Fellows from EMBL`)
- To set the status of the pull request, use the built-in github feature to set the PR as Draft or Ready for review.
- To indicate the type of change (such as bugfix or new feature), use a github pull request label.
- If pr is not ready for review, set it draft. We agreed in the team, that if the PR in the draft state, no one will review it.
- Remember, that you can trigger end2end tests manually
