### PR TITLE
SS-1880 Harden source code URL validation to a blocking error

### DIFF
--- a/apps/background_tasks/tasks/validation.py
+++ b/apps/background_tasks/tasks/validation.py
@@ -289,18 +289,9 @@ class ImagePublicValidator(BaseBackgroundTask):
 
 @TASK_REGISTRY.register(
     name="validate_source_code_url",
-    is_critical=False,
+    is_critical=True,
     execution_order=2,
-    app_types=[
-        "customapp",
-        "dashapp",
-        # "depictio",
-        "gradio",
-        "shinyapp",
-        "shinyproxyapp",
-        "streamlit",
-        # "tissuumaps",
-    ],
+    app_types=SOURCE_CODE_URL_APP_TYPES,
 )
 class SourceCodeUrlValidator(BaseBackgroundTask):
     """
@@ -333,27 +324,12 @@ class SourceCodeUrlValidator(BaseBackgroundTask):
             "SOURCE_CODE_URL_VALIDATION_TIMEOUT_SECONDS",
             10,
         )
-        failure_mode = getattr(
-            settings,
-            "SOURCE_CODE_URL_VALIDATION_FAILURE_MODE",
-            "warning",
-        ).lower()
-        if failure_mode not in ("warning", "error"):
-            failure_mode = "warning"
-        treat_as_error = failure_mode == "error"
 
-        def fail(message: str, status_code: int | None = None) -> dict[str, Any]:
-            if treat_as_error:
-                detail = message
-                if status_code is not None:
-                    detail = f"{message} (HTTP {status_code})"
-                raise ValueError(detail)
-            return {
-                "valid": True,
-                "validation_warning": message,
-                "status_code": status_code,
-                "url": url,
-            }
+        def fail(message: str, status_code: int | None = None) -> None:
+            detail = message
+            if status_code is not None:
+                detail = f"{message} (HTTP {status_code})"
+            raise ValueError(detail)
 
         try:
             # Prefer HEAD to avoid downloading body; allow_redirects to follow 3xx

--- a/apps/tests/test_source_code_url_validator.py
+++ b/apps/tests/test_source_code_url_validator.py
@@ -135,24 +135,16 @@ def test_source_code_url_validator_falls_back_to_get_on_head_405(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_source_code_url_validator_non_2xx_warning_mode(settings, monkeypatch):
-    settings.SOURCE_CODE_URL_VALIDATION_FAILURE_MODE = "warning"
-    instance = _make_custom_app(source_code_url="https://example.org/missing")
+def test_source_code_url_validator_head_network_error_error_mode(settings, monkeypatch):
+    instance = _make_custom_app(source_code_url="https://example.org/repo")
 
-    mock_resp = MagicMock()
-    mock_resp.status_code = 404
+    def boom(*a, **kw):
+        raise requests.ConnectionError("refused")
 
-    monkeypatch.setattr(
-        "apps.background_tasks.tasks.validation.requests.head",
-        lambda *a, **kw: mock_resp,
-    )
+    monkeypatch.setattr("apps.background_tasks.tasks.validation.requests.head", boom)
 
-    result = SourceCodeUrlValidator().execute(instance)
-
-    assert result["valid"] is True
-    assert "validation_warning" in result
-    assert "404" in result["validation_warning"]
-    assert result["status_code"] == 404
+    with pytest.raises(ValueError, match="unreachable"):
+        SourceCodeUrlValidator().execute(instance)
 
 
 @pytest.mark.django_db
@@ -170,19 +162,3 @@ def test_source_code_url_validator_non_2xx_error_mode(settings, monkeypatch):
 
     with pytest.raises(ValueError, match="returned unreachable"):
         SourceCodeUrlValidator().execute(instance)
-
-
-@pytest.mark.django_db
-def test_source_code_url_validator_head_network_error_warning_mode(settings, monkeypatch):
-    settings.SOURCE_CODE_URL_VALIDATION_FAILURE_MODE = "warning"
-    instance = _make_custom_app(source_code_url="https://example.org/repo")
-
-    def boom(*a, **kw):
-        raise requests.ConnectionError("refused")
-
-    monkeypatch.setattr("apps.background_tasks.tasks.validation.requests.head", boom)
-
-    result = SourceCodeUrlValidator().execute(instance)
-
-    assert result["valid"] is True
-    assert "unreachable" in result["validation_warning"].lower()

--- a/studio/settings.py
+++ b/studio/settings.py
@@ -481,8 +481,6 @@ GITHUB_API_TOKEN = os.getenv("GITHUB_API_TOKEN")
 GITHUB_API_USERNAME = os.getenv("GITHUB_API_USERNAME")
 
 # Source code URL validation (background task)
-# Failure mode: "warning" = report in result but do not fail; "error" = raise and fail task
-SOURCE_CODE_URL_VALIDATION_FAILURE_MODE = os.getenv("SOURCE_CODE_URL_VALIDATION_FAILURE_MODE", "warning").lower()
 SOURCE_CODE_URL_VALIDATION_TIMEOUT_SECONDS = int(os.getenv("SOURCE_CODE_URL_VALIDATION_TIMEOUT_SECONDS", "10"))
 
 # Invenio API


### PR DESCRIPTION
## Description

Converts the `SourceCodeUrlValidator` background task from a soft warning into a hard, blocking validation error, and simplifies its configuration.

- `SourceCodeUrlValidator` is now registered with `is_critical=True` (was `False`), so a failed source code URL check now fails the app validation task instead of only being reported.
- Removed the `SOURCE_CODE_URL_VALIDATION_FAILURE_MODE` setting/env var (`warning`/`error` toggle) and the `treat_as_error` branch in `validation.py`. The validator now always raises `ValueError` on an unreachable/non-2xx source code URL instead of returning a `validation_warning`.
- Consolidated the validator's `app_types` list into the existing `SOURCE_CODE_URL_APP_TYPES` constant, which also re-enables `depictio` and `tissuumaps` (previously commented out) so they get the same source code URL check as the other app types.
- Removed the now-unused `SOURCE_CODE_URL_VALIDATION_FAILURE_MODE` setting from `studio/settings.py`.
- Updated `apps/tests/test_source_code_url_validator.py`: removed the warning-mode tests and renamed/adjusted the remaining tests to assert the blocking-error behavior.

Related: SS-1880

## Checklist

> If you're unsure about any of the items below, don't hesitate to ask. We're here to help!
> This is simply a reminder of what we are going to look for before merging your code.

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have added or updated unit and end2end tests or a manual test case to complement my changes
- [x] I have ran unit and end2end tests
- [ ] I have considered accessibility for UI changes and reviewed pre-commit/Pa11y results or documented a manual check
- [x] I have updated the related documentation (if necessary)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request
- [x] In the case I have modified settings.py, then I have also updated the studio-settings-configmap.yaml file in serve-charts (Not needed)
- [ ] In case your changes are large enough, did you deploy your changes to develop instance?

🤖 Generated with [Claude Code](https://claude.com/claude-code)